### PR TITLE
Updated build.zig and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ qbe
 config.h
 .comfile
 *.out
-zig-cache
+.zig-cache
 zig-out

--- a/build.zig
+++ b/build.zig
@@ -80,7 +80,7 @@ pub fn build(b: *std.Build) !void {
 
     const libqbe = b.addStaticLibrary(.{
         .name = "qbe-lib",
-        .root_source_file = .{ .path = "src/qbe.zig" },
+        .root_source_file = b.path("src/qbe.zig"),
         .target = target,
         .optimize = .ReleaseFast,
     });
@@ -124,10 +124,10 @@ pub fn build(b: *std.Build) !void {
     });
 
     const module = b.addModule("qbe-zig", .{
-        .root_source_file = .{ .path = "src/qbe.zig" },
+        .root_source_file = b.path("src/qbe.zig"),
     });
 
-    module.addIncludePath(.{ .path = "" });
+    module.addIncludePath(b.path(""));
 
     b.installArtifact(libqbe);
 }


### PR DESCRIPTION
Updated build.zig to work with Zig 0.13.0, and updated the .gitignore to properly ignore `.zig-cache` now.