### PR TITLE
Add GitHub Action + fix Linux build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master
-      - name: zig build test
+      - name: zig build
         working-directory: "./${{matrix.dir}}"
-        run: zig build test
+        run: zig build
   lint:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
         dir: ["", "example"]
         os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
-      - name: Install build-essential
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: qbe-zig
+on: push
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        dir: ["", "example"]
+        os: [ubuntu-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+      - name: zig build test
+        working-directory: "./${{matrix.dir}}"
+        run: zig build test
+  lint:
+    strategy:
+      matrix:
+        dir: ["", "example"]
+        os: [ubuntu-latest]
+    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+      - name: zig fmt
+        working-directory: "./${{matrix.dir}}"
+        run: zig fmt --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install build-essential
-        run: sudo apt-get install -y build-essential
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
+      - name: Install build-essential
+        run: sudo apt-get install -y build-essential
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master

--- a/build.zig
+++ b/build.zig
@@ -78,6 +78,8 @@ pub fn build(b: *std.Build) !void {
 
     b.installArtifact(qbe_exe);
 
+    qbe_exe.linkLibC();
+
     const libqbe = b.addStaticLibrary(.{
         .name = "qbe-lib",
         .root_source_file = b.path("src/qbe.zig"),

--- a/build.zig
+++ b/build.zig
@@ -7,32 +7,33 @@ pub fn build(b: *std.Build) !void {
     _ = optimize; // See comment below
 
     // Generate config.h with appropriate default qbe target
-    var config_file = try std.fs.cwd().createFile("config.h", .{});
-    defer config_file.close();
+    const wf = b.addWriteFiles();
+    const config_h_path = "config.h";
 
-    switch (target.result.os.tag) {
+    const config_h_define = switch (target.result.os.tag) {
         .macos => switch (target.result.cpu.arch) {
-            .aarch64 => try config_file.writeAll(
-                \\#define Deftgt T_arm64_apple
-            ),
-            .x86_64 => try config_file.writeAll(
-                \\#define Deftgt T_amd64_apple
-            ),
+            .aarch64 =>
+            \\#define Deftgt T_arm64_apple
+            ,
+            .x86_64 =>
+            \\#define Deftgt T_amd64_apple
+            ,
             else => return error.MacosUnsupportedArchitectureOn,
         },
         else => switch (target.result.cpu.arch) {
-            .aarch64 => try config_file.writeAll(
-                \\#define Deftgt T_arm64
-            ),
-            .x86_64 => try config_file.writeAll(
-                \\#define Deftgt T_amd64_sysv
-            ),
-            .riscv64 => try config_file.writeAll(
-                \\#define Deftgt T_rv64
-            ),
+            .aarch64 =>
+            \\#define Deftgt T_arm64
+            ,
+            .x86_64 =>
+            \\#define Deftgt T_amd64_sysv
+            ,
+            .riscv64 =>
+            \\#define Deftgt T_rv64
+            ,
             else => return error.UnsupportedArchitecture,
         },
-    }
+    };
+    _ = wf.add(config_h_path, config_h_define);
 
     const qbe_exe = b.addExecutable(.{
         .name = "qbe",
@@ -75,6 +76,8 @@ pub fn build(b: *std.Build) !void {
             "rv64/targ.c",
         },
     });
+
+    qbe_exe.addIncludePath(wf.getDirectory());
 
     b.installArtifact(qbe_exe);
 
@@ -124,6 +127,8 @@ pub fn build(b: *std.Build) !void {
             "rv64/targ.c",
         },
     });
+
+    libqbe.addIncludePath(wf.getDirectory());
 
     const module = b.addModule("qbe-zig", .{
         .root_source_file = b.path("src/qbe.zig"),

--- a/example/build.zig
+++ b/example/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "example",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -57,7 +57,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const exe_unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
# Description

Adds a GitHub Action for automated testing.

Also fixes building on Linux, which I think just wasn't working at all. The issues were:
- not being able to find `assert.h` because I was missing a `linkLibC()` on the QBE exe
- the creation of the `config.h` being wrong insofar as it was being generated into the directory where `zig build` is run, not into the `src/` directory as expected. To make this work properly I am now using `addWriteFiles` (see https://ziglang.org/learn/build-system/#write-files) to generate the `config.h` into `zig-cache` and then making sure to `addIncludePath` with `wf.getDirectory()` so that `#include "config.h"` finds the file in the cache (instead of in `src/). I believe this is the way.