### PR TITLE
refactor: update build.zig for Zig 0.15.1 compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,8 +37,10 @@ pub fn build(b: *std.Build) !void {
 
     const qbe_exe = b.addExecutable(.{
         .name = "qbe",
-        .target = target,
-        .optimize = .ReleaseFast, // If we try to use .ReleaseSafe or .Debug invoking qbe traps
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = .ReleaseFast, // If we try to use .ReleaseSafe or .Debug invoking qbe traps
+        }),
     });
 
     qbe_exe.addCSourceFiles(.{
@@ -84,11 +86,14 @@ pub fn build(b: *std.Build) !void {
 
     qbe_exe.linkLibC();
 
-    const libqbe = b.addStaticLibrary(.{
+    const libqbe = b.addLibrary(.{
         .name = "qbe-lib",
-        .root_source_file = b.path("src/qbe.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/qbe.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        }),
+        .linkage = .static,
     });
 
     libqbe.linkLibC();


### PR DESCRIPTION
### Summary

Zig 0.15.1 introduced breaking changes to the build system API compared to 0.14.1. this PR updates `build.zig` to align with the new APIs so the project can build correctly with Zig 0.15.1.

### Changes

* replaced `b.addStaticLibrary` with `b.addLibrary` using `.linkage = .static`
* updated executables and libraries to use `root_module = b.createModule(...)` instead of passing `target` and `optimize` directly
* adjusted module creation to match the new `std.Build` API
* no functional changes to build outputs, only API updates for compatibility